### PR TITLE
Add vercel.json configuration for proper Vercel deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,9 +67,6 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview"
-    "dev": "vite"
-    "build": "vite build"
-    "preview": "vite preview"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,9 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview"
+    "dev": "vite"
+    "build": "vite build"
+    "preview": "vite preview"
   },
   "repository": {
     "type": "git",

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,15 @@
+{
+  "builds": [
+    {
+      "src": "package.json",
+      "use": "@vercel/static-build",
+      "config": { "distDir": "dist" }
+    }
+  ],
+  "routes": [
+    {
+      "src": "/(.*)",
+      "dest": "/dist/$1"
+    }
+  ]
+}


### PR DESCRIPTION
This pull request adds a vercel.json configuration file to enable correct deployment on Vercel. 
It sets the build command to use Vite and defines the output directory as "dist". 
This ensures the site builds and serves properly as a static app on Vercel.